### PR TITLE
repo 5.5 should not be enabled by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-remi_enable_php55: true
+remi_enable_php55: false
 remi_enable_php56: false


### PR DESCRIPTION
Repo 5.5 should not be enabled by default.
Althought I understand that it may be some default for your configuration, it is not the default of all galaxy users. The base package should come with roles in galaxy, and only users in need should enable things for their specific need.

Please consider merging it for benefit of others.
Overall, this role is great!
